### PR TITLE
日報の言及機能を作る My report mention

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -54,6 +54,7 @@ class ReportsController < ApplicationController
   end
 
   def create_report_link
+    @report.report_links.destroy_all
     mentioning_report_ids = @report.content.scan(%r{http://127.0.0.1:3000/reports/(\d+)})
     return if mentioning_report_ids.empty?
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -22,24 +22,22 @@ class ReportsController < ApplicationController
     ActiveRecord::Base.transaction do
       @report = current_user.reports.new(report_params)
 
-      if @report.save
-        @report.create_report_link
-        redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
-      else
-        render :new, status: :unprocessable_entity
-        raise ActiveRecord::Rollback
-      end
+      raise ActiveRecord::Rollback unless @report.save
+
+      @report.create_report_link
+      redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
     end
     render :new, status: :unprocessable_entity unless @report.persisted?
   end
 
   def update
-    if @report.update(report_params)
+    ActiveRecord::Base.transaction do
+      raise ActiveRecord::Rollback unless @report.update(report_params)
+
       @report.create_report_link
       redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
-    else
-      render :edit, status: :unprocessable_entity
     end
+    render :edit, status: :unprocessable_entity unless @report.persisted?
   end
 
   def destroy

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -22,6 +22,7 @@ class ReportsController < ApplicationController
     @report = current_user.reports.new(report_params)
 
     if @report.save
+      mentioning_report(@report.content)
       redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
     else
       render :new, status: :unprocessable_entity
@@ -30,6 +31,7 @@ class ReportsController < ApplicationController
 
   def update
     if @report.update(report_params)
+      mentioning_report(@report.content)
       redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
     else
       render :edit, status: :unprocessable_entity
@@ -38,7 +40,7 @@ class ReportsController < ApplicationController
 
   def destroy
     @report.destroy
-
+    mentioning_report(@report.content)
     redirect_to reports_url, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
   end
 
@@ -50,5 +52,14 @@ class ReportsController < ApplicationController
 
   def report_params
     params.require(:report).permit(:title, :content)
+  end
+
+  def mentioning_report(text)
+    mentioning_reports = text.scan(%r{http://127.0.0.1:3000/reports/\d+}) # http://127.0.0.1:3000/reports/55
+    return if mentioning_reports.nil?
+
+    mentioning_reports.each do |url|
+      puts "取得成功: #{url}"
+    end
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -21,12 +21,12 @@ class ReportsController < ApplicationController
   def create
     @report = current_user.reports.new(report_params)
 
-    redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human) if @report.create_report_and_mention
+    redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human) if @report.save_with_mentions
     render :new, status: :unprocessable_entity unless @report.persisted?
   end
 
   def update
-    redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human) if @report.update_report_and_mention
+    redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human) if @report.update_with_mentions(report_params)
     render :edit, status: :unprocessable_entity unless @report.persisted?
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -22,7 +22,7 @@ class ReportsController < ApplicationController
     @report = current_user.reports.new(report_params)
 
     if @report.save
-      mentioning_report(@report.content)
+      create_report_link
       redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
     else
       render :new, status: :unprocessable_entity
@@ -31,7 +31,7 @@ class ReportsController < ApplicationController
 
   def update
     if @report.update(report_params)
-      mentioning_report(@report.content)
+      create_report_link
       redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
     else
       render :edit, status: :unprocessable_entity
@@ -40,7 +40,6 @@ class ReportsController < ApplicationController
 
   def destroy
     @report.destroy
-    mentioning_report(@report.content)
     redirect_to reports_url, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
   end
 
@@ -54,12 +53,13 @@ class ReportsController < ApplicationController
     params.require(:report).permit(:title, :content)
   end
 
-  def mentioning_report(text)
-    mentioning_reports = text.scan(%r{http://127.0.0.1:3000/reports/\d+}) # http://127.0.0.1:3000/reports/55
-    return if mentioning_reports.nil?
+  def create_report_link
+    mentioning_report_ids = @report.content.scan(%r{http://127.0.0.1:3000/reports/(\d+)})
+    return if mentioning_report_ids.empty?
 
-    mentioning_reports.each do |url|
-      puts "取得成功: #{url}"
+    mentioning_report_ids.each do |id|
+      to_report = Report.find(id[0].to_i)
+      @report.link(to_report)
     end
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -9,6 +9,7 @@ class ReportsController < ApplicationController
 
   def show
     @report = Report.find(params[:id])
+    @outgoing_mentions = @report.outgoing_mentions.order(:id).presence
   end
 
   # GET /reports/new

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -19,14 +19,18 @@ class ReportsController < ApplicationController
   def edit; end
 
   def create
-    @report = current_user.reports.new(report_params)
+    ActiveRecord::Base.transaction do
+      @report = current_user.reports.new(report_params)
 
-    if @report.save
-      @report.create_report_link
-      redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
-    else
-      render :new, status: :unprocessable_entity
+      if @report.save
+        @report.create_report_link
+        redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
+      else
+        render :new, status: :unprocessable_entity
+        raise ActiveRecord::Rollback
+      end
     end
+    render :new, status: :unprocessable_entity unless @report.persisted?
   end
 
   def update

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -19,24 +19,14 @@ class ReportsController < ApplicationController
   def edit; end
 
   def create
-    ActiveRecord::Base.transaction do
-      @report = current_user.reports.new(report_params)
+    @report = current_user.reports.new(report_params)
 
-      raise ActiveRecord::Rollback unless @report.save
-
-      @report.create_report_link
-      redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
-    end
+    redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human) if @report.create_report_and_mention
     render :new, status: :unprocessable_entity unless @report.persisted?
   end
 
   def update
-    ActiveRecord::Base.transaction do
-      raise ActiveRecord::Rollback unless @report.update(report_params)
-
-      @report.create_report_link
-      redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
-    end
+    redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human) if @report.update_report_and_mention
     render :edit, status: :unprocessable_entity unless @report.persisted?
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -22,7 +22,7 @@ class ReportsController < ApplicationController
     @report = current_user.reports.new(report_params)
 
     if @report.save
-      create_report_link
+      @report.create_report_link
       redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
     else
       render :new, status: :unprocessable_entity
@@ -31,7 +31,7 @@ class ReportsController < ApplicationController
 
   def update
     if @report.update(report_params)
-      create_report_link
+      @report.create_report_link
       redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
     else
       render :edit, status: :unprocessable_entity
@@ -51,16 +51,5 @@ class ReportsController < ApplicationController
 
   def report_params
     params.require(:report).permit(:title, :content)
-  end
-
-  def create_report_link
-    @report.report_links.destroy_all
-    mentioning_report_ids = @report.content.scan(%r{http://127.0.0.1:3000/reports/(\d+)})
-    return if mentioning_report_ids.empty?
-
-    mentioning_report_ids.each do |id|
-      to_report = Report.find(id[0].to_i)
-      @report.link(to_report)
-    end
   end
 end

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ReportsHelper
+  def display_mentioned_reports(mention)
+    link_to "#{mention.mentioned_report.user.name}: #{mention.mentioned_report.title}", mention.mentioned_report
+  end
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -4,12 +4,24 @@ class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy
 
-  has_many :report_links, foreign_key: 'from_report_id'
-  has_many :report_links, foreign_key: 'to_report_id'
-  has_many :reports, through: :report_links, source: :from_report
+  has_many :report_links, dependent: :destroy
+  has_many :to_reports, through: :report_links, source: :to_report
+  has_many :my_report_links, class_name: 'ReportLink', foreign_key: 'to_report_id', dependent: :destroy
+  has_many :reports, through: :my_report_links, source: :report
 
   validates :title, presence: true
   validates :content, presence: true
+
+  def link(to_report)
+    return if self == to_report
+
+    report_links.find_or_create_by(to_report_id: to_report.id)
+  end
+
+  def unlink(to_report)
+    report_link_to = report_links.find_by(to_report_id: to_report.id)
+    report_link_to&.destroy
+  end
 
   def editable?(target_user)
     user == target_user

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -4,6 +4,10 @@ class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy
 
+  has_many :report_links, foreign_key: 'from_report_id'
+  has_many :report_links, foreign_key: 'to_report_id'
+  has_many :reports, through: :report_links, source: :from_report
+
   validates :title, presence: true
   validates :content, presence: true
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -22,12 +22,6 @@ class Report < ApplicationRecord
     end
   end
 
-  def link(mentioning_report)
-    return if self == mentioning_report
-
-    mentioned_links.find_or_create_by!(mentioning_report_id: mentioning_report.id)
-  end
-
   def editable?(target_user)
     user == target_user
   end
@@ -43,4 +37,12 @@ class Report < ApplicationRecord
   def mentioned_reports
     my_mentioned_links.order(:id).presence
   end
+end
+
+private
+
+def link(mentioning_report)
+  return if self == mentioning_report
+
+  mentioned_links.find_or_create_by!(mentioning_report_id: mentioning_report.id)
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -15,7 +15,6 @@ class Report < ApplicationRecord
   def create_report_link
     mentioned_links.destroy_all
     mentioning_report_ids = content.scan(%r{http://127.0.0.1:3000/reports/(\d+)})
-    return if mentioning_report_ids.empty?
 
     mentioning_report_ids.each do |id|
       mentioning_report = Report.find(id[0].to_i)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -30,19 +30,11 @@ class Report < ApplicationRecord
     created_at.to_date
   end
 
-  def mentioning_reports
-    mentioned_by_reports.order(:id).presence
+  private
+
+  def link(mentioning_report)
+    return if self == mentioning_report
+
+    mentioned_by_reports.find_or_create_by!(mentioning_report_id: mentioning_report.id)
   end
-
-  def mentioned_reports
-    my_mentioned_by_reports.order(:id).presence
-  end
-end
-
-private
-
-def link(mentioning_report)
-  return if self == mentioning_report
-
-  mentioned_by_reports.find_or_create_by!(mentioning_report_id: mentioning_report.id)
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -4,16 +4,16 @@ class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy
 
-  has_many :mentioned_by_reports, class_name: 'ReportLink', foreign_key: 'mentioned_report_id', dependent: :destroy, inverse_of: :mentioned_report
-  has_many :mentioning_reports, through: :mentioned_by_reports, source: :mentioning_report
-  has_many :mentions_to_reports, class_name: 'ReportLink', foreign_key: 'mentioning_report_id', dependent: :destroy, inverse_of: :mentioning_report
-  has_many :mentioned_reports, through: :mentions_to_reports, source: :mentioned_report
+  has_many :outgoing_mentions, class_name: 'ReportLink', foreign_key: 'mentioning_report_id', dependent: :destroy, inverse_of: :mentioned_report
+  has_many :mentioning_reports, through: :outgoing_mentions, source: :mentioned_report
+  has_many :incoming_mentions, class_name: 'ReportLink', foreign_key: 'mentioned_report_id', dependent: :destroy, inverse_of: :mentioning_report
+  has_many :mentioned_reports, through: :incoming_mentions, source: :mentioning_report
 
   validates :title, presence: true
   validates :content, presence: true
 
   def create_report_link
-    mentioned_by_reports.destroy_all
+    outgoing_mentions.destroy_all
     mentioning_report_ids = content.scan(%r{http://127.0.0.1:3000/reports/(\d+)})
 
     mentioning_report_ids.each do |id|
@@ -33,8 +33,8 @@ class Report < ApplicationRecord
   private
 
   def link(mentioning_report)
-    return if self == mentioning_report
+    return if id == mentioning_report.id
 
-    mentioned_by_reports.find_or_create_by!(mentioning_report_id: mentioning_report.id)
+    mentioning_report.outgoing_mentions.find_or_create_by!(mentioned_report: self)
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -4,23 +4,29 @@ class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy
 
-  has_many :report_links, dependent: :destroy
+  has_many :report_links, foreign_key: 'from_report_id', dependent: :destroy, inverse_of: :from_report
   has_many :to_reports, through: :report_links, source: :to_report
-  has_many :my_report_links, class_name: 'ReportLink', foreign_key: 'to_report_id', dependent: :destroy
-  has_many :reports, through: :my_report_links, source: :report
+  has_many :my_report_links, class_name: 'ReportLink', foreign_key: 'to_report_id', dependent: :destroy, inverse_of: :to_report
+  has_many :from_reports, through: :my_report_links, source: :report
 
   validates :title, presence: true
   validates :content, presence: true
 
+  def create_report_link
+    report_links.destroy_all
+    mentioning_report_ids = content.scan(%r{http://127.0.0.1:3000/reports/(\d+)})
+    return if mentioning_report_ids.empty?
+
+    mentioning_report_ids.each do |id|
+      to_report = Report.find(id[0].to_i)
+      link(to_report)
+    end
+  end
+
   def link(to_report)
     return if self == to_report
 
-    report_links.find_or_create_by(to_report_id: to_report.id)
-  end
-
-  def unlink(to_report)
-    report_link_to = report_links.find_by(to_report_id: to_report.id)
-    report_link_to&.destroy
+    report_links.find_or_create_by!(to_report_id: to_report.id)
   end
 
   def editable?(target_user)
@@ -29,5 +35,13 @@ class Report < ApplicationRecord
 
   def created_on
     created_at.to_date
+  end
+
+  def mentioning_reports
+    report_links.order(:id).presence
+  end
+
+  def mentioned_reports
+    my_report_links.order(:id).presence
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -17,8 +17,8 @@ class Report < ApplicationRecord
     mentioning_report_ids = content.scan(%r{http://127.0.0.1:3000/reports/(\d+)})
 
     mentioning_report_ids.each do |id|
-      mentioning_report = Report.find(id[0].to_i)
-      link(mentioning_report)
+      mentioning_report = Report.find(id[0])
+      create_mention_link(mentioning_report)
     end
   end
 
@@ -32,7 +32,7 @@ class Report < ApplicationRecord
 
   private
 
-  def link(mentioning_report)
+  def create_mention_link(mentioning_report)
     return if id == mentioning_report.id
 
     mentioning_report.outgoing_mentions.find_or_create_by!(mentioned_report: self)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -4,7 +4,7 @@ class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy
 
-  has_many :mentioned_links, foreign_key: 'mentioned_report_id', dependent: :destroy, inverse_of: :mentioned_report
+  has_many :mentioned_by_reports, foreign_key: 'mentioned_report_id', dependent: :destroy, inverse_of: :mentioned_report
   has_many :mentioning_reports, through: :mentioned_by_reports, source: :mentioning_report
   has_many :mentions_to_reports, class_name: 'ReportLink', foreign_key: 'mentioning_report_id', dependent: :destroy, inverse_of: :mentioning_report
   has_many :mentioned_reports, through: :mentions_to_reports, source: :report
@@ -13,7 +13,7 @@ class Report < ApplicationRecord
   validates :content, presence: true
 
   def create_report_link
-    mentioned_links.destroy_all
+    mentioned_by_reports.destroy_all
     mentioning_report_ids = content.scan(%r{http://127.0.0.1:3000/reports/(\d+)})
 
     mentioning_report_ids.each do |id|
@@ -31,11 +31,11 @@ class Report < ApplicationRecord
   end
 
   def mentioning_reports
-    mentioned_links.order(:id).presence
+    mentioned_by_reports.order(:id).presence
   end
 
   def mentioned_reports
-    my_mentioned_links.order(:id).presence
+    my_mentioned_by_reports.order(:id).presence
   end
 end
 
@@ -44,5 +44,5 @@ private
 def link(mentioning_report)
   return if self == mentioning_report
 
-  mentioned_links.find_or_create_by!(mentioning_report_id: mentioning_report.id)
+  mentioned_by_reports.find_or_create_by!(mentioning_report_id: mentioning_report.id)
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -4,10 +4,10 @@ class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy
 
-  has_many :mentioned_by_reports, foreign_key: 'mentioned_report_id', dependent: :destroy, inverse_of: :mentioned_report
+  has_many :mentioned_by_reports, class_name: 'ReportLink', foreign_key: 'mentioned_report_id', dependent: :destroy, inverse_of: :mentioned_report
   has_many :mentioning_reports, through: :mentioned_by_reports, source: :mentioning_report
   has_many :mentions_to_reports, class_name: 'ReportLink', foreign_key: 'mentioning_report_id', dependent: :destroy, inverse_of: :mentioning_report
-  has_many :mentioned_reports, through: :mentions_to_reports, source: :report
+  has_many :mentioned_reports, through: :mentions_to_reports, source: :mentioned_report
 
   validates :title, presence: true
   validates :content, presence: true

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -4,29 +4,29 @@ class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy
 
-  has_many :report_links, foreign_key: 'from_report_id', dependent: :destroy, inverse_of: :from_report
-  has_many :to_reports, through: :report_links, source: :to_report
-  has_many :my_report_links, class_name: 'ReportLink', foreign_key: 'to_report_id', dependent: :destroy, inverse_of: :to_report
-  has_many :from_reports, through: :my_report_links, source: :report
+  has_many :mentioned_links, foreign_key: 'mentioned_report_id', dependent: :destroy, inverse_of: :mentioned_report
+  has_many :mentioning_reports, through: :mentioned_by_reports, source: :mentioning_report
+  has_many :mentions_to_reports, class_name: 'ReportLink', foreign_key: 'mentioning_report_id', dependent: :destroy, inverse_of: :mentioning_report
+  has_many :mentioned_reports, through: :mentions_to_reports, source: :report
 
   validates :title, presence: true
   validates :content, presence: true
 
   def create_report_link
-    report_links.destroy_all
+    mentioned_links.destroy_all
     mentioning_report_ids = content.scan(%r{http://127.0.0.1:3000/reports/(\d+)})
     return if mentioning_report_ids.empty?
 
     mentioning_report_ids.each do |id|
-      to_report = Report.find(id[0].to_i)
-      link(to_report)
+      mentioning_report = Report.find(id[0].to_i)
+      link(mentioning_report)
     end
   end
 
-  def link(to_report)
-    return if self == to_report
+  def link(mentioning_report)
+    return if self == mentioning_report
 
-    report_links.find_or_create_by!(to_report_id: to_report.id)
+    mentioned_links.find_or_create_by!(mentioning_report_id: mentioning_report.id)
   end
 
   def editable?(target_user)
@@ -38,10 +38,10 @@ class Report < ApplicationRecord
   end
 
   def mentioning_reports
-    report_links.order(:id).presence
+    mentioned_links.order(:id).presence
   end
 
   def mentioned_reports
-    my_report_links.order(:id).presence
+    my_mentioned_links.order(:id).presence
   end
 end

--- a/app/models/report_link.rb
+++ b/app/models/report_link.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ReportLink < ApplicationRecord
+  belongs_to :from_report_id, class_name: 'Report'
+  belongs_to :to_report_id, class_name: 'Report'
+
+  validates :from_report_id, presence: true
+  validates :to_report_id, presence: true
+end

--- a/app/models/report_link.rb
+++ b/app/models/report_link.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class ReportLink < ApplicationRecord
-  belongs_to :from_report, class_name: 'Report', inverse_of: :report_links
-  belongs_to :to_report, class_name: 'Report', inverse_of: :my_report_links
+  belongs_to :mentioned_reports, class_name: 'Report', inverse_of: :report_links
+  belongs_to :mentioning_reports, class_name: 'Report', inverse_of: :my_report_links
 
-  validates :from_report, uniqueness: { scope: :to_report, message: 'その言及関係の組み合わせは既に存在します。' }
+  validates :mentioned_reports, uniqueness: { scope: :mentioning_reports }
 end

--- a/app/models/report_link.rb
+++ b/app/models/report_link.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class ReportLink < ApplicationRecord
-  belongs_to :from_report_id, class_name: 'Report'
-  belongs_to :to_report_id, class_name: 'Report'
+  belongs_to :report
+  belongs_to :to_report, class_name: 'Report', foreign_key: 'report_id'
 
-  validates :from_report_id, presence: true
+  validates :report_id, presence: true
   validates :to_report_id, presence: true
 end

--- a/app/models/report_link.rb
+++ b/app/models/report_link.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class ReportLink < ApplicationRecord
-  belongs_to :report
-  belongs_to :to_report, class_name: 'Report', foreign_key: 'report_id'
+  belongs_to :from_report, class_name: 'Report', inverse_of: :report_links
+  belongs_to :to_report, class_name: 'Report', inverse_of: :my_report_links
 
-  validates :report_id, presence: true
-  validates :to_report_id, presence: true
+  validates :from_report, uniqueness: { scope: :to_report, message: 'その言及関係の組み合わせは既に存在します。' }
 end

--- a/app/models/report_link.rb
+++ b/app/models/report_link.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class ReportLink < ApplicationRecord
-  belongs_to :mentioned_reports, class_name: 'Report', inverse_of: :report_links
-  belongs_to :mentioning_reports, class_name: 'Report', inverse_of: :my_report_links
+  belongs_to :mentioned_report, class_name: 'Report', inverse_of: :mentioned_by_reports
+  belongs_to :mentioning_report, class_name: 'Report', inverse_of: :mentions_to_reports
 
-  validates :mentioned_reports, uniqueness: { scope: :mentioning_reports }
+  validates :mentioned_report, uniqueness: { scope: :mentioning_report }
 end

--- a/app/models/report_link.rb
+++ b/app/models/report_link.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class ReportLink < ApplicationRecord
-  belongs_to :mentioned_report, class_name: 'Report', inverse_of: :mentioned_by_reports
-  belongs_to :mentioning_report, class_name: 'Report', inverse_of: :mentions_to_reports
+  belongs_to :mentioned_report, class_name: 'Report', inverse_of: :incoming_mentions
+  belongs_to :mentioning_report, class_name: 'Report', inverse_of: :outgoing_mentions
 
   validates :mentioned_report, uniqueness: { scope: :mentioning_report }
 end

--- a/app/views/reports/_report.html.erb
+++ b/app/views/reports/_report.html.erb
@@ -16,7 +16,7 @@
 
   <p>
     <strong><%= Report.human_attribute_name(:created_on) %>:</strong>
-    <%= l report.created_on %>
+    <%= report.created_on %>
   </p>
 
 </div>

--- a/app/views/reports/_report.html.erb
+++ b/app/views/reports/_report.html.erb
@@ -16,7 +16,7 @@
 
   <p>
     <strong><%= Report.human_attribute_name(:created_on) %>:</strong>
-    <%= report.created_on %>
+    <%= l report.created_on %>
   </p>
 
 </div>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -16,3 +16,5 @@
     <%= button_to t('views.common.destroy', name: Report.model_name.human.downcase), @report, method: :delete %>
   <% end %>
 </nav>
+
+<%= render 'shared/report_links', report: @report %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -17,4 +17,4 @@
   <% end %>
 </nav>
 
-<%= render 'shared/report_links', report: @report %>
+<%= render 'shared/report_links', outgoing_mentions: @outgoing_mentions%>

--- a/app/views/shared/_report_links.html.erb
+++ b/app/views/shared/_report_links.html.erb
@@ -1,10 +1,10 @@
 <div>
-  <% if (mentions_to_reports = @report.mentions_to_reports.order(:id).presence) %>
+  <% if (outgoing_mentions = @report.outgoing_mentions.order(:id).presence) %>
     <h3><%= t('.mentions') %></h3>
     <ul>
-      <% mentions_to_reports.each do |mentions_to_report| %>
+      <% outgoing_mentions.each do |outgoing_mention| %>
         <li>
-          <%= link_to "#{mentions_to_report.mentioned_report.user.name}: #{mentions_to_report.mentioned_report.title}", mentions_to_report.mentioned_report %>
+          <%= link_to "#{outgoing_mention.mentioned_report.user.name}: #{outgoing_mention.mentioned_report.title}", outgoing_mention.mentioned_report %>
         </li>
       <% end %>
     </ul>

--- a/app/views/shared/_report_links.html.erb
+++ b/app/views/shared/_report_links.html.erb
@@ -1,10 +1,10 @@
 <div>
-  <% if (mentioned_by_reports = @report.mentioned_by_reports.order(:id).presence) %>
+  <% if (mentions_to_reports = @report.mentions_to_reports.order(:id).presence) %>
     <h3><%= t('.mentions') %></h3>
     <ul>
-      <% mentioned_by_reports.each do |mentioned_by_report| %>
+      <% mentions_to_reports.each do |mentions_to_report| %>
         <li>
-          <%= link_to "#{mentioned_by_report.mentioned_report.user.name}: #{mentioned_by_report.mentioned_report.title}", mentioned_by_report.mentioned_report %>
+          <%= link_to "#{mentions_to_report.mentioned_report.user.name}: #{mentions_to_report.mentioned_report.title}", mentions_to_report.mentioned_report %>
         </li>
       <% end %>
     </ul>

--- a/app/views/shared/_report_links.html.erb
+++ b/app/views/shared/_report_links.html.erb
@@ -1,10 +1,10 @@
-<div class="report-container">
-  <% if (report_links = @report.my_report_links.order(:id).presence) %>
-    <h3>この日報に言及している日報があります。</h3>
+<div>
+  <% if (report_links = @report.mentioned_reports) %>
+    <h3><%= t('.mentions') %></h3>
     <ul>
       <% report_links.each do |report_link| %>
         <li>
-            <%= link_to "#{report_link.report.user.name}: #{report_link.report.title}", report_link.report %>
+          <%= link_to "#{report_link.from_report.user.name}: #{report_link.from_report.title}", report_link.from_report %>
         </li>
       <% end %>
     </ul>

--- a/app/views/shared/_report_links.html.erb
+++ b/app/views/shared/_report_links.html.erb
@@ -1,0 +1,12 @@
+<div class="report-container">
+  <% if (report_links = @report.my_report_links.order(:id).presence) %>
+    <h3>この日報に言及している日報があります。</h3>
+    <ul>
+      <% report_links.each do |report_link| %>
+        <li>
+            <%= link_to "#{report_link.report.user.name}: #{report_link.report.title}", report_link.report %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>

--- a/app/views/shared/_report_links.html.erb
+++ b/app/views/shared/_report_links.html.erb
@@ -4,7 +4,7 @@
     <ul>
       <% report_links.each do |report_link| %>
         <li>
-          <%= link_to "#{report_link.from_report.user.name}: #{report_link.from_report.title}", report_link.from_report %>
+          <%= link_to "#{report_link.mentioned_report.user.name}: #{report_link.mentioned_report.title}", report_link.mentioned_report %>
         </li>
       <% end %>
     </ul>

--- a/app/views/shared/_report_links.html.erb
+++ b/app/views/shared/_report_links.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <% if (outgoing_mentions = @report.outgoing_mentions.order(:id).presence) %>
+  <% if outgoing_mentions %>
     <h3><%= t('.mentions') %></h3>
     <ul>
       <% outgoing_mentions.each do |outgoing_mention| %>

--- a/app/views/shared/_report_links.html.erb
+++ b/app/views/shared/_report_links.html.erb
@@ -4,7 +4,7 @@
     <ul>
       <% outgoing_mentions.each do |outgoing_mention| %>
         <li>
-          <%= link_to "#{outgoing_mention.mentioned_report.user.name}: #{outgoing_mention.mentioned_report.title}", outgoing_mention.mentioned_report %>
+          <%= display_mentioned_reports(outgoing_mention) %>
         </li>
       <% end %>
     </ul>

--- a/app/views/shared/_report_links.html.erb
+++ b/app/views/shared/_report_links.html.erb
@@ -1,10 +1,10 @@
 <div>
-  <% if (report_links = @report.mentioned_reports) %>
+  <% if (mentioned_by_reports = @report.mentioned_by_reports.order(:id).presence) %>
     <h3><%= t('.mentions') %></h3>
     <ul>
-      <% report_links.each do |report_link| %>
+      <% mentioned_by_reports.each do |mentioned_by_report| %>
         <li>
-          <%= link_to "#{report_link.mentioned_report.user.name}: #{report_link.mentioned_report.title}", report_link.mentioned_report %>
+          <%= link_to "#{mentioned_by_report.mentioned_report.user.name}: #{mentioned_by_report.mentioned_report.title}", mentioned_by_report.mentioned_report %>
         </li>
       <% end %>
     </ul>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -216,6 +216,8 @@ ja:
       create: コメントする
       delete: 削除
       no_comments: コメントはまだありません
+    report_links:
+      mentions: この日報に言及している人がいます
   # devise-i18n-viewsをオーバーライド
   devise:
     registrations:

--- a/db/migrate/20231024081533_create_report_links.rb
+++ b/db/migrate/20231024081533_create_report_links.rb
@@ -1,9 +1,9 @@
 class CreateReportLinks < ActiveRecord::Migration[7.0]
   def change
     create_table :report_links do |t|
-      t.references :report, foreign_key: true
+      t.references :from_report, foreign_key: { to_table: :reports }
       t.references :to_report, foreign_key: { to_table: :reports }
-      t.index %i[report_id to_report_id], unique: true
+      t.index %i[from_report_id to_report_id], unique: true
 
       t.timestamps
     end

--- a/db/migrate/20231024081533_create_report_links.rb
+++ b/db/migrate/20231024081533_create_report_links.rb
@@ -1,0 +1,11 @@
+class CreateReportLinks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :report_links do |t|
+      t.references :from_report, foreign_key: { to_table: :reports }
+      t.references :to_report, foreign_key: { to_table: :reports }
+      t.index %i[from_report_id to_report_id], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231024081533_create_report_links.rb
+++ b/db/migrate/20231024081533_create_report_links.rb
@@ -1,9 +1,9 @@
 class CreateReportLinks < ActiveRecord::Migration[7.0]
   def change
     create_table :report_links do |t|
-      t.references :from_report, foreign_key: { to_table: :reports }
-      t.references :to_report, foreign_key: { to_table: :reports }
-      t.index %i[from_report_id to_report_id], unique: true
+      t.references :mentioned_report, foreign_key: { to_table: :reports }
+      t.references :mentioning_report, foreign_key: { to_table: :reports }
+      t.index %i[mentioned_report_id mentioning_report_id], unique: true, name: 'index_mentioning_mentioned_report_ids'
 
       t.timestamps
     end

--- a/db/migrate/20231024081533_create_report_links.rb
+++ b/db/migrate/20231024081533_create_report_links.rb
@@ -1,9 +1,9 @@
 class CreateReportLinks < ActiveRecord::Migration[7.0]
   def change
     create_table :report_links do |t|
-      t.references :from_report, foreign_key: { to_table: :reports }
+      t.references :report, foreign_key: true
       t.references :to_report, foreign_key: { to_table: :reports }
-      t.index %i[from_report_id to_report_id], unique: true
+      t.index %i[report_id to_report_id], unique: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,8 +14,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_24_081533) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -59,6 +59,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
+  create_table "report_links", force: :cascade do |t|
+    t.integer "from_report_id"
+    t.integer "to_report_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["from_report_id", "to_report_id"], name: "index_report_links_on_from_report_id_and_to_report_id", unique: true
+    t.index ["from_report_id"], name: "index_report_links_on_from_report_id"
+    t.index ["to_report_id"], name: "index_report_links_on_to_report_id"
+  end
+
   create_table "reports", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "title", null: false
@@ -87,5 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "users"
+  add_foreign_key "report_links", "reports", column: "from_report_id"
+  add_foreign_key "report_links", "reports", column: "to_report_id"
   add_foreign_key "reports", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,12 +60,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_24_081533) do
   end
 
   create_table "report_links", force: :cascade do |t|
-    t.integer "report_id"
+    t.integer "from_report_id"
     t.integer "to_report_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["report_id", "to_report_id"], name: "index_report_links_on_report_id_and_to_report_id", unique: true
-    t.index ["report_id"], name: "index_report_links_on_report_id"
+    t.index ["from_report_id", "to_report_id"], name: "index_report_links_on_from_report_id_and_to_report_id", unique: true
+    t.index ["from_report_id"], name: "index_report_links_on_from_report_id"
     t.index ["to_report_id"], name: "index_report_links_on_to_report_id"
   end
 
@@ -97,7 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_24_081533) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "users"
-  add_foreign_key "report_links", "reports"
+  add_foreign_key "report_links", "reports", column: "from_report_id"
   add_foreign_key "report_links", "reports", column: "to_report_id"
   add_foreign_key "reports", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,13 +60,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_24_081533) do
   end
 
   create_table "report_links", force: :cascade do |t|
-    t.integer "from_report_id"
-    t.integer "to_report_id"
+    t.integer "mentioned_report_id"
+    t.integer "mentioning_report_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["from_report_id", "to_report_id"], name: "index_report_links_on_from_report_id_and_to_report_id", unique: true
-    t.index ["from_report_id"], name: "index_report_links_on_from_report_id"
-    t.index ["to_report_id"], name: "index_report_links_on_to_report_id"
+    t.index ["mentioned_report_id", "mentioning_report_id"], name: "index_mentioning_mentioned_report_ids", unique: true
+    t.index ["mentioned_report_id"], name: "index_report_links_on_mentioned_report_id"
+    t.index ["mentioning_report_id"], name: "index_report_links_on_mentioning_report_id"
   end
 
   create_table "reports", force: :cascade do |t|
@@ -97,7 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_24_081533) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "users"
-  add_foreign_key "report_links", "reports", column: "from_report_id"
-  add_foreign_key "report_links", "reports", column: "to_report_id"
+  add_foreign_key "report_links", "reports", column: "mentioned_report_id"
+  add_foreign_key "report_links", "reports", column: "mentioning_report_id"
   add_foreign_key "reports", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,12 +60,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_24_081533) do
   end
 
   create_table "report_links", force: :cascade do |t|
-    t.integer "from_report_id"
+    t.integer "report_id"
     t.integer "to_report_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["from_report_id", "to_report_id"], name: "index_report_links_on_from_report_id_and_to_report_id", unique: true
-    t.index ["from_report_id"], name: "index_report_links_on_from_report_id"
+    t.index ["report_id", "to_report_id"], name: "index_report_links_on_report_id_and_to_report_id", unique: true
+    t.index ["report_id"], name: "index_report_links_on_report_id"
     t.index ["to_report_id"], name: "index_report_links_on_to_report_id"
   end
 
@@ -97,7 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_24_081533) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "users"
-  add_foreign_key "report_links", "reports", column: "from_report_id"
+  add_foreign_key "report_links", "reports"
   add_foreign_key "report_links", "reports", column: "to_report_id"
   add_foreign_key "reports", "users"
 end


### PR DESCRIPTION
## 使い方
```
# dbの設定
$ rails db:reset

# サーバーを建てる
$ rails s 

# [http://127.0.0.1:3000]
```

## 実施内容
- 日報作成時に内容に参照したい他の日報のURLを含めると、参照されている日報から言及されている日報の一覧が分かるように表示する機能を追加した。

## PRポイント
- 多対多の自己参照型のモデル定義をしたが、方法は合っているか。
- 実装要件にあった`mentioning_reports`をReportに追加実装したが、機能としては使わなかったのでどこで使うことを想定していたのか。

## 実行結果

###　動作画面

<img width="662" alt="スクリーンショット 2023-10-30 10 12 15" src="https://github.com/shunhamm/fjord-books_app-2023/assets/52060354/b7e1a2db-7d41-4d4b-8b27-8cc7a26a75b7">

- このように日報作成時にある日報のURLをテキストに含める。

<img width="626" alt="スクリーンショット 2023-10-30 10 13 14" src="https://github.com/shunhamm/fjord-books_app-2023/assets/52060354/f95f073a-293c-483e-a4e1-ffb37663ff9f">

- 画面の言及している日報の一覧が表示される。

<img width="645" alt="スクリーンショット 2023-10-30 10 13 30" src="https://github.com/shunhamm/fjord-books_app-2023/assets/52060354/06296b96-4c24-455e-b2f7-dee44b662412">

- 言及元の日報を消去したり、テキストからURL情報を排除すると、言及先の一覧からも消える。


### erblint

<img width="494" alt="スクリーンショット 2023-10-30 10 10 54" src="https://github.com/shunhamm/fjord-books_app-2023/assets/52060354/5aacc5f1-8534-4d2d-9dd6-36ccca2edb74">


### rubocop 
(指摘されている内容があるが、これは元のファイルの内容であり今回の作業スコープ外なので変更しなかった。)

<img width="689" alt="スクリーンショット 2023-10-30 10 08 53" src="https://github.com/shunhamm/fjord-books_app-2023/assets/52060354/5847cb67-89c7-4718-a884-47c4e248effb">
